### PR TITLE
Multi-trait Manhattan plot: Reverse point sampling

### DIFF
--- a/R/CMplot.r
+++ b/R/CMplot.r
@@ -1,6 +1,7 @@
 #Version: 4.0.0
 #Data: 2021/12/12
 #Author: Lilin Yin
+#Contributor: Marcel Schilling
 
 CMplot <- function(
     Pmap,
@@ -2075,12 +2076,11 @@ CMplot <- function(
                     segments(chr.border.pos[b], Min, chr.border.pos[b], Max, col="grey45", lwd=lwd.axis, lty=2)
                 }
             }
-            do <- TRUE
             sam.index <- list()
             trait_max_n <- 0
             trait_max <- 0
             for(l in 1:R){
-                sam.index[[l]] <- c(1:nrow(Pmap))[is_visable[[l]]]
+                sam.index[[l]] <- c(1:nrow(Pmap))[is_visable[[l]] & !is.na(logpvalueT[,l])]
                 if(length(sam.index[[l]]) >= trait_max_n){
                     trait_max_n = length(sam.index[[l]])
                     trait_max = l
@@ -2091,13 +2091,19 @@ CMplot <- function(
             #sam.num <- ceiling(nrow(Pmap)/100)
             sam.num <- 1000
             cat_bar <- seq(1, 100, 1)
-            while(do){
+            trait_n <- sapply(sam.index, length)
+            trait_sams <- ceiling(trait_n / sam.num)
+            trait_max_sams <- max(trait_sams)
+            trait_1st_sam <- trait_max_sams - trait_sams + 1
+            trait_full_sams <- floor(trait_n / sam.num)
+            trait_1st_full_sam <- trait_max_sams - trait_full_sams + 1
+            for(sam in 1:trait_max_sams) {
                 for(i in 1:R){
-                    if(length(sam.index[[i]]) == 0){
+                    if(sam < trait_1st_sam[i]){
                         # nothing
                     }else{
-                        if(length(sam.index[[i]]) < sam.num){
-                            plot.index <- sam.index[[i]]
+                        if(sam < trait_1st_full_sam[i]){
+                            plot.index <- sample(sam.index[[i]], trait_n[i] %% sam.num, replace=FALSE)
                         }else{
                             plot.index <- sample(sam.index[[i]], sam.num, replace=FALSE)
                         }
@@ -2116,7 +2122,6 @@ CMplot <- function(
                         if(progress == 100) cat("\n")
                     }
                 }
-                if(length(sam.index[[trait_max]]) == 0) do <- FALSE
             }
 
             if(!is.null(threshold)){


### PR DESCRIPTION
When plotting multiple traits in a single Manhattan plot, overplotting is unavoidable. CMplot dampens its effect by randomly sampling 1000 points from each trait to plot at a time. However, it does so starting with all traits in the first chunk of points to plot and removes traits from the sampling (and thus plotting) list once they have been 'depleted' (*i.e.* all points for that trait have been plotted). Thus, if one trait has much more (non-NA) points that the other(s), it can dominate the last chunk of points plotted resulting in visible overplotting 'bias' towards that sample.

This PR addresses this issue by inverting the plot (or rather: sampling) order: 'Larger' traits are preferred in the initial chunk(s) of points to plot until equal numbers of points remain to be plotted for each trait. This way, the 'extra' points accumulate in the background instead of the foreground, removing the visible 'bias' caused by the overplotting.

Here is an example:

```R
# Get latest development version of `CMplot` and `pig60K` example data.
library(CMplot)
source("https://raw.githubusercontent.com/YinLiLin/CMplot/fe3b0ed0130bac60d61cb23aaec778435c8d1bce/R/CMplot.r")
data(pig60K)

# Create mulit-tracks Manhattan plot with default parameters (for reference).
set.seed(42)
CMplot(pig60K, plot.type="m", multracks=TRUE, file.output=FALSE)
```

![multi-traits Manhattan plot using unmodified example data and current master branch](https://user-images.githubusercontent.com/12913701/160093780-26011b16-e7b2-4cde-ae62-aa6b4ce138e5.png)

```R
# Randomly drop p-values for most points in two out of three traits.
set.seed(42)
pig60Kmod <- pig60K
n <- nrow(pig60Kmod)
na1 <- sample(1:n, as.integer(.8 * n))
na3 <- sample(1:n, as.integer(.95 * n))
pig60Kmod$trait1[na1] <- NA
pig60Kmod$trait3[na3] <- NA

# Observe 'larger' trait visually dominate the plot.
set.seed(42)
CMplot(pig60Kmod, plot.type="m", multracks=TRUE, file.output=FALSE)
```

![multi-traits Manhattan plot using modified example data and current master branch](https://user-images.githubusercontent.com/12913701/160093971-1ca2dda1-9689-4055-a173-d01622131b87.png)

```R
# Repeat the same plot with reversed sampling order as suggested in
# this PR.
source("https://raw.githubusercontent.com/YinLiLin/CMplot/a62c829fea8c4d74b609fcefb3dd8a73895ade26/R/CMplot.r")
set.seed(42)
CMplot(pig60Kmod, plot.type="m", multracks=TRUE, file.output=FALSE)
```

![multi-traits Manhattan plot using modified example data and coude suggested here](https://user-images.githubusercontent.com/12913701/160094058-a290386e-99fe-4647-9229-31ecbc060828.png)

```R
# Repeat plot with unmodified example data to rule out any unwanted
# side-effects of the reversed sampling.
set.seed(42)
CMplot(pig60K, plot.type="m", multracks=TRUE, file.output=FALSE)
```

![multi-traits Manhattan plot using unmodified example data and coude suggested here](https://user-images.githubusercontent.com/12913701/160094153-9a0e846e-47a2-42f6-9ed1-b01e09ba1d29.png)